### PR TITLE
Update the Internship outreach page

### DIFF
--- a/outreach/academic-programs/interns/index.njk
+++ b/outreach/academic-programs/interns/index.njk
@@ -13,10 +13,10 @@ title: Research Student Internships
 As part of Cloudflare’s effort to build collaborations with academia, we host research focused internships all year long. 
 <br>
 <br>
-The work at Cloudflare Research provides meaningful and engaging internship opportunities putting theory into practice as a deeply embedded member of the team. Interns collaborate cross-functionally in research projects and are encouraged to ship code and write a blog post and a peer-reviewed publication at the end of their internship. Many former interns have joined Cloudflare full-time after their internship.
+The work at Cloudflare Research provides meaningful and engaging internship opportunities putting theory into practice as a deeply embedded member of the team. Interns collaborate cross-functionally in research projects and are encouraged to ship code and write a blog post or a peer-reviewed publication at the end of their internship. Many former interns have joined Cloudflare full-time after their internship.
 <br>
 <br>
-You can read testimonials about internship experiences as <a href="https://blog.cloudflare.com/internship-experience-cryptography-engineer/" target="_blank">Cryptography Engineer</a> and <a href="https://blog.cloudflare.com/internship-experience-research-engineer/" target="_blank">Research Engineer</a>. If these experiences sound appealing <a href="https://www.cloudflare.com/careers/jobs/?department=University&location=default" target="_blank"><b>join us</b></a>!
+You can read testimonials about internship experiences as <a href="https://blog.cloudflare.com/internship-experience-cryptography-engineer/" target="_blank">Cryptography Engineer</a> and <a href="https://blog.cloudflare.com/internship-experience-research-engineer/" target="_blank">Research Engineer</a>. If these experiences sound appealing <a href="https://www.cloudflare.com/careers/jobs/?department=University" target="_blank"><b>join us</b></a>!
 <br>
 <br>
 <h3 style="margin-bottom: -1rem;">Current and Former Interns</h3>


### PR DESCRIPTION
The url "https://www.cloudflare.com/careers/jobs/?department=University&location=default" has the `location=default` parameter that breaks the careers page such that no results are shown for any department.

Remove the `location` parameter to fix the issue.

To verify, go to:
"https://www.cloudflare.com/careers/jobs/?department=University&location=default" breaks the job/careers page.
"https://www.cloudflare.com/careers/jobs/?department=University" fixes the issues.
