### PR TITLE
Add Tancrède Lepoint profile and fix author slug in Eaton2023

### DIFF
--- a/content/people/tancrede-lepoint.md
+++ b/content/people/tancrede-lepoint.md
@@ -1,0 +1,9 @@
+---
+title: Tancrède Lepoint
+position: External Collaborator
+avatar: placeholder.png
+slug: tancrede-lepoint
+type: external
+---
+
+External collaborator on Cloudflare Research publications.

--- a/content/publications/Eaton2023.md
+++ b/content/publications/Eaton2023.md
@@ -3,7 +3,7 @@ title: "Security Analysis of Signature Schemes with Key Blinding"
 year: 2023
 authors:
   - edward-eaton
-  - tancrde-lepoint
+  - tancrede-lepoint
   - christopher-wood
 url: https://eprint.iacr.org/2023/380
 related_interests:


### PR DESCRIPTION
Fix the author slug due to accent and add empty external collaborator profile for the name to properly appear
