### PR TITLE
Update publication content for "Rethinking the Networking Stack for Serverless Environments: A Sidecar Approach"

### DIFF
--- a/content/publications/Seshagiri2025.md
+++ b/content/publications/Seshagiri2025.md
@@ -7,7 +7,8 @@ authors:
   - abhinav-gupta
   - vahab-jabrayilov
   - avani-wildani
-  - Kostis Kaffes
+  - kostis-kaffes
+doi: 10.1145/3698038.3698561
 related_interests:
   - storage
 pillar: fast

--- a/content/publications/Seshagiri2025.md
+++ b/content/publications/Seshagiri2025.md
@@ -1,15 +1,15 @@
 ---
 title: "Rethinking the Networking Stack for Serverless Environments: A Sidecar Approach"
-year: 2025
-location: "2025 USENIX Annual Technical Conference (USENIX ATC 25), Santa Clara, CA, July 2025"
+year: 2024
+location: "Proceedings of the 2024 ACM Symposium on Cloud Computing"
 authors:
-  - amogh-seshagiri
+  - vishwanath-seshagiri
+  - abhinav-gupta
+  - vahab-jabrayilov
   - avani-wildani
-  - marwan-fayed
-url: https://www.usenix.org/conference/atc25/presentation/seshagiri
+  - Kostis Kaffes
 related_interests:
-  - distributed-systems
-  - networking
+  - storage
 pillar: fast
 metaDescription: "Sidecar-based networking architecture for serverless environments addressing cold-start latency, connection reuse, and security isolation challenges in modern serverless computing platforms."
 ---
@@ -23,5 +23,4 @@ is a prime source of user-perceived, end-to-end latency. In this
 paper, we present a detailed vision of a new, sidecar-based
 networking stack for serverless environments. Our primary
 design goal is to provide low-overhead networking while
-maintaining existing security guarantees. We outline the research challenges in both the control and the data plane that
-the community needs to tackle before such a sidecar architecture can be used in practice.
+maintaining existing security guarantees. We outline the research challenges in both the control and the data plane that the community needs to tackle before such a sidecar architecture can be used in practice.


### PR DESCRIPTION
The wrong content was listed on this article. I reverted the meta data to match this commit hash: `1f675bd9b83e7ccb895780e87f712907c0743b44`