### PR TITLE
Moves Featured Research into a Config File

### DIFF
--- a/content/publications/Seshagiri2025.md
+++ b/content/publications/Seshagiri2025.md
@@ -7,7 +7,8 @@ authors:
   - abhinav-gupta
   - vahab-jabrayilov
   - avani-wildani
-  - Kostis Kaffes
+  - kostis-kaffes
+doi: 10.1145/3698038.3698561
 related_interests:
   - storage
 pillar: fast

--- a/content/publications/Seshagiri2025.md
+++ b/content/publications/Seshagiri2025.md
@@ -1,15 +1,15 @@
 ---
 title: "Rethinking the Networking Stack for Serverless Environments: A Sidecar Approach"
-year: 2025
-location: "2025 USENIX Annual Technical Conference (USENIX ATC 25), Santa Clara, CA, July 2025"
+year: 2024
+location: "Proceedings of the 2024 ACM Symposium on Cloud Computing"
 authors:
-  - amogh-seshagiri
+  - vishwanath-seshagiri
+  - abhinav-gupta
+  - vahab-jabrayilov
   - avani-wildani
-  - marwan-fayed
-url: https://www.usenix.org/conference/atc25/presentation/seshagiri
+  - Kostis Kaffes
 related_interests:
-  - distributed-systems
-  - networking
+  - storage
 pillar: fast
 metaDescription: "Sidecar-based networking architecture for serverless environments addressing cold-start latency, connection reuse, and security isolation challenges in modern serverless computing platforms."
 ---
@@ -23,5 +23,4 @@ is a prime source of user-perceived, end-to-end latency. In this
 paper, we present a detailed vision of a new, sidecar-based
 networking stack for serverless environments. Our primary
 design goal is to provide low-overhead networking while
-maintaining existing security guarantees. We outline the research challenges in both the control and the data plane that
-the community needs to tackle before such a sidecar architecture can be used in practice.
+maintaining existing security guarantees. We outline the research challenges in both the control and the data plane that the community needs to tackle before such a sidecar architecture can be used in practice.

--- a/content/site.toml
+++ b/content/site.toml
@@ -1,0 +1,6 @@
+[main.featuredResearch]
+publication = "galicer2025"
+title = "Auditing Key Transparency"
+description = "WhatsApp's 2023 deployment of key transparency reduces reliance on centralized servers for distributing end-to-end encryption keys. This research explores Cloudflare's integration to audit WhatsApp's key transparency data structure in a live production environment."
+link = "/galicer2025"
+buttonLabel = "Read the Full Article"

--- a/src/components/home/FeaturedResearch.astro
+++ b/src/components/home/FeaturedResearch.astro
@@ -1,6 +1,10 @@
 ---
 import Icon from "../Icon.astro";
 import SeeMore from "../SeeMore.astro";
+import { getCollection } from "astro:content";
+
+const [siteSettings] = await getCollection("site");
+const { title, description, link, buttonLabel } = siteSettings.data.featuredResearch;
 ---
 
 <section class="interior-content border-b-2 border-page-border connector-bl connector-br">
@@ -12,11 +16,11 @@ import SeeMore from "../SeeMore.astro";
   </div>
   <div class="px-8 md:px-4 lg:px-12 py-10">
     <div class="font-mono text-sm text-stack mb-4">Featured Research</div>
-    <a href="/galicer2025" class="mb-8 block group/link">
-      <h1 class="heading inline group-hover/link:text-blue text-2xl sm:text-3xl lg:text-4xl">Auditing Key Transparency</h1>
+    <a href={link} class="mb-8 block group/link">
+      <h1 class="heading inline group-hover/link:text-blue text-2xl sm:text-3xl lg:text-4xl">{title}</h1>
     </a>
-    <p>WhatsApp's 2023 deployment of key transparency reduces reliance on centralized servers for distributing end-to-end encryption keys. This research explores Cloudflare's integration to audit WhatsApp's key transparency data structure in a live production environment.</p>
-    <SeeMore href="/galicer2025">Read the Full Article</SeeMore>
+    <p>{description}</p>
+    <SeeMore href={link}>{buttonLabel}</SeeMore>
   </div>
   <div class="relative">
     <picture>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -9,6 +9,19 @@ import { blogLoader } from "./loaders/blog";
 import { z } from "astro/zod";
 
 // 4. Define your collection(s)
+const site = defineCollection({
+  loader: file("./content/site.toml"),
+  schema: z.object({
+    featuredResearch: z.object({
+      publication: reference("publications"),
+      title: z.string(),
+      description: z.string(),
+      link: z.string(),
+      buttonLabel: z.string().default("Read the Full Article"),
+    }),
+  }),
+});
+
 const people = defineCollection({
   loader: glob({ pattern: "**/*.md", base: "./content/people" }),
   schema: z.object({
@@ -89,4 +102,11 @@ const blog = defineCollection({
 });
 
 // 5. Export a single `collections` object to register your collection(s)
-export const collections = { people, publications, tags, presentations, blog };
+export const collections = {
+  site,
+  people,
+  publications,
+  tags,
+  presentations,
+  blog,
+};


### PR DESCRIPTION
Previously, the featured research section was hard coded into the `<FeaturedResearch />` component.

<img width="1149" height="467" alt="CleanShot 2026-04-09 at 16 21 10" src="https://github.com/user-attachments/assets/bac180ce-1a43-43ae-8adf-663fb7b45d3c" />

Now, the content is controlled through the `content/site.toml` file, making it easier to update.

Contents includes:

```
[main.featuredResearch]
publication = "publication ID"
title = "Title of the Publication"
description = "Description that will appear on the homepage"
link = "link that you want the button to point to"
buttonLabel = "button label"
```