### PR TITLE
Adds missing people files

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Content is managed through Astro's Content Collections located in the `/content`
 - **Tags**: Topic categorization for filtering content
 
 ### Featured Research
+
 Within the [`/content/site.toml`](./content/site.toml) file, you can configure the featured research section on the homepage. It must follow this structure:
 
 ```toml
@@ -78,6 +79,7 @@ buttonLabel = "Read the Full Article"
 ```
 
 ### People
+
 All people are located within the [`/content/people`](./content/people) directory.
 
 They must follow this structure:
@@ -102,6 +104,7 @@ Only `active` and `alumni` types are displayed on the team page.
 Avatars are stored in the [`/public/images/people`](./public/images/people) directory and should be named after the person's slug.
 
 ### Publications
+
 All publications are located within the [`/content/publications`](./content/publications) directory.
 
 They must follow this structure:
@@ -126,6 +129,7 @@ Publication content
 ```
 
 ### Presentations
+
 All presentations are located within the [`/content/presentations`](./content/presentations) directory.
 
 They must follow this structure:
@@ -142,6 +146,7 @@ Presentation content
 ```
 
 ### Tags
+
 Tags are maintained in the [`/content/tags`](./content/tags) directory. They are used to categorize publications and presentations.
 
 Tags must follow this structure:

--- a/README.md
+++ b/README.md
@@ -78,8 +78,52 @@ buttonLabel = "Read the Full Article"
 ```
 
 ### People
+All people are located within the [`/content/people`](./content/people) directory.
+
+They must follow this structure:
+
+```markdown
+---
+title: "Person's Name"
+position: "Position"
+author_name: "Person's Name"
+status: "current" | "inactive"
+twitter: "twitter-handle"
+bluesky: "bluesky-handle"
+blog_author: "blog-author"
+avatar: "/images/people/person-name.jpg"
+slug: "person-name"
+type: "active" | "alumni" | "external" | "intern" | "inactive"
+---
+```
+
+Only `active` and `alumni` types are displayed on the team page.
+
+Avatars are stored in the [`/public/images/people`](./public/images/people) directory and should be named after the person's slug.
 
 ### Publications
+All publications are located within the [`/content/publications`](./content/publications) directory.
+
+They must follow this structure:
+
+```markdown
+---
+title: "Publication Name"
+year: year
+location: "Location"
+authors:
+  - author-slug
+url: https://example.com
+doi: doi
+related_interests:
+  - related-interest-slug
+pillar: "fast" | "private" | "safe" | "reliable" | "measurable"
+tags:
+  - tag-slug
+---
+
+Publication content
+```
 
 ### Presentations
 All presentations are located within the [`/content/presentations`](./content/presentations) directory.
@@ -89,19 +133,9 @@ They must follow this structure:
 ```markdown
 ---
 title: "Presentation Name"
-year: 2021
-location: IACR International Conference on Public-Key Cryptography, pp. 261-289. Springer, Cham, 2021.
-authors:
-  - martin-albrecht
-  - alex-davidson
-  - amit-deo
-  - nigel-p-smart
-url: https://example.com
-doi: 10.1007/978-3-030-75248-4_10
-related_interests:
-  - cryptography
-pillar: private
-metaDescription: "Research on constructing the first round-optimal VOPRF protocol secure from lattice hardness assumptions, enabling post-quantum secure verifiable oblivious pseudorandom functions with applications to password authentication and private set intersection."
+youtube: "youtube-url"
+thumbnail: "thumbnail-url"
+year: year
 ---
 
 Presentation content

--- a/README.md
+++ b/README.md
@@ -65,6 +65,64 @@ Content is managed through Astro's Content Collections located in the `/content`
 - **Presentations**: Conference talks and keynotes
 - **Tags**: Topic categorization for filtering content
 
+### Featured Research
+Within the [`/content/site.toml`](./content/site.toml) file, you can configure the featured research section on the homepage. It must follow this structure:
+
+```toml
+[main.featuredResearch]
+publication = "publication-slug"
+title = "Publication Title"
+description = "Publication description"
+link = "/publication-slug"
+buttonLabel = "Read the Full Article"
+```
+
+### People
+
+### Publications
+
+### Presentations
+All presentations are located within the [`/content/presentations`](./content/presentations) directory.
+
+They must follow this structure:
+
+```markdown
+---
+title: "Presentation Name"
+year: 2021
+location: IACR International Conference on Public-Key Cryptography, pp. 261-289. Springer, Cham, 2021.
+authors:
+  - martin-albrecht
+  - alex-davidson
+  - amit-deo
+  - nigel-p-smart
+url: https://example.com
+doi: 10.1007/978-3-030-75248-4_10
+related_interests:
+  - cryptography
+pillar: private
+metaDescription: "Research on constructing the first round-optimal VOPRF protocol secure from lattice hardness assumptions, enabling post-quantum secure verifiable oblivious pseudorandom functions with applications to password authentication and private set intersection."
+---
+
+Presentation content
+```
+
+### Tags
+Tags are maintained in the [`/content/tags`](./content/tags) directory. They are used to categorize publications and presentations.
+
+Tags must follow this structure:
+
+```toml
+---
+name: "Tag Name"
+slug: "tag-slug"
+description: "Tag description"
+color: "pink"
+---
+```
+
+When you want to link a tag to a publication or presentation, you can do so by adding the tag slug to the `tags` array in the frontmatter of the content file (see [Publications](#publications) for an example).
+
 ## 🎨 Design System
 
 The site uses a custom design system with:

--- a/content/people/bruce-m-maggs.md
+++ b/content/people/bruce-m-maggs.md
@@ -1,0 +1,9 @@
+---
+title: Bruce M. Maggs
+position: External Collaborator
+avatar: placeholder.png
+slug: bruce-m-maggs
+type: external
+---
+
+External collaborator on Cloudflare Research publications.

--- a/content/people/darrell-d-e-long.md
+++ b/content/people/darrell-d-e-long.md
@@ -1,0 +1,9 @@
+---
+title: Darrell D. E. Long
+position: External Collaborator
+avatar: placeholder.png
+slug: darrell-d-e-long
+type: external
+---
+
+External collaborator on Cloudflare Research publications.

--- a/content/people/devashish-r-purandare.md
+++ b/content/people/devashish-r-purandare.md
@@ -1,0 +1,9 @@
+---
+title: Devashish R. Purandare
+position: External Collaborator
+avatar: placeholder.png
+slug: devashish-r-purandare
+type: external
+---
+
+External collaborator on Cloudflare Research publications.

--- a/content/people/devon-obrien.md
+++ b/content/people/devon-obrien.md
@@ -1,0 +1,9 @@
+---
+title: Devon O'Brien
+position: External Collaborator
+avatar: placeholder.png
+slug: devon-obrien
+type: external
+---
+
+External collaborator on Cloudflare Research publications.

--- a/content/people/ethan-l-miller.md
+++ b/content/people/ethan-l-miller.md
@@ -1,0 +1,9 @@
+---
+title: Ethan L. Miller
+position: External Collaborator
+avatar: placeholder.png
+slug: ethan-l-miller
+type: external
+---
+
+External collaborator on Cloudflare Research publications.

--- a/content/people/hossam-s-hassanein.md
+++ b/content/people/hossam-s-hassanein.md
@@ -1,0 +1,9 @@
+---
+title: Hossam S. Hassanein
+position: External Collaborator
+avatar: placeholder.png
+slug: hossam-s-hassanein
+type: external
+---
+
+External collaborator on Cloudflare Research publications.

--- a/content/people/j-alex-halderman.md
+++ b/content/people/j-alex-halderman.md
@@ -1,0 +1,9 @@
+---
+title: J. Alex Halderman
+position: External Collaborator
+avatar: placeholder.png
+slug: j-alex-halderman
+type: external
+---
+
+External collaborator on Cloudflare Research publications.

--- a/content/people/joo-diogo-duarte.md
+++ b/content/people/joo-diogo-duarte.md
@@ -1,0 +1,9 @@
+---
+title: João Diogo Duarte
+position: External Collaborator
+avatar: placeholder.png
+slug: joo-diogo-duarte
+type: external
+---
+
+External collaborator on Cloudflare Research publications.

--- a/content/people/marek-vavrua.md
+++ b/content/people/marek-vavrua.md
@@ -1,0 +1,9 @@
+---
+title: Marek Vavrua
+position: External Collaborator
+avatar: placeholder.png
+slug: marek-vavrua
+type: external
+---
+
+External collaborator on Cloudflare Research publications.

--- a/content/people/nigel-p-smart.md
+++ b/content/people/nigel-p-smart.md
@@ -1,0 +1,9 @@
+---
+title: Nigel P. Smart
+position: External Collaborator
+avatar: placeholder.png
+slug: nigel-p-smart
+type: external
+---
+
+External collaborator on Cloudflare Research publications.

--- a/content/people/pratik-soni.md
+++ b/content/people/pratik-soni.md
@@ -1,0 +1,9 @@
+---
+title: Pratik Soni
+position: External Collaborator
+avatar: placeholder.png
+slug: pratik-soni
+type: external
+---
+
+External collaborator on Cloudflare Research publications.

--- a/content/people/riad-s-wahby.md
+++ b/content/people/riad-s-wahby.md
@@ -1,8 +1,8 @@
 ---
-title: Rahul Chatterjee
+title: Riad S. Wahby
 position: External Collaborator
 avatar: placeholder.png
-slug: rahul-chatterjee
+slug: riad-s-wahby
 type: external
 ---
 

--- a/content/people/sharief-m-a-oteafy.md
+++ b/content/people/sharief-m-a-oteafy.md
@@ -1,0 +1,9 @@
+---
+title: Sharief M. A. Oteafy
+position: External Collaborator
+avatar: placeholder.png
+slug: sharief-m-a-oteafy
+type: external
+---
+
+External collaborator on Cloudflare Research publications.

--- a/content/people/sofa-celi.md
+++ b/content/people/sofa-celi.md
@@ -1,0 +1,9 @@
+---
+title: Sofía Celi
+position: External Collaborator
+avatar: placeholder.png
+slug: sofa-celi
+type: external
+---
+
+External collaborator on Cloudflare Research publications.

--- a/content/people/tancrede-lepoint.md
+++ b/content/people/tancrede-lepoint.md
@@ -1,0 +1,9 @@
+---
+title: Tancrède Lepoint
+position: External Collaborator
+avatar: placeholder.png
+slug: tancrede-lepoint
+type: external
+---
+
+External collaborator on Cloudflare Research publications.

--- a/content/publications/Eaton2023.md
+++ b/content/publications/Eaton2023.md
@@ -3,7 +3,7 @@ title: "Security Analysis of Signature Schemes with Key Blinding"
 year: 2023
 authors:
   - edward-eaton
-  - tancrde-lepoint
+  - tancrede-lepoint
   - christopher-wood
 url: https://eprint.iacr.org/2023/380
 related_interests:


### PR DESCRIPTION
## Add Missing External Collaborators

This PR adds 15 external collaborators who were previously referenced in publications but didn't have profile pages, plus updates the README with comprehensive documentation for content structure.

### Changes

#### Added External People Profiles:
- Bruce M. Maggs
- Darrell D. E. Long
- Devashish R. Purandare
- Devon O'Brien
- Ethan L. Miller
- Hossam S. Hassanein
- J. Alex Halderman
- João Diogo Duarte
- Marek Vavruša
- Nigel P. Smart
- Pratik Soni
- Riad S. Wahby
- Sharief M. A. Oteafy
- Sofía Celis
- Tancrede Lepoint

#### Documentation Updates:
- Added comprehensive frontmatter templates for People, Publications, and Presentations
- Documented `status` field values: `"current"` | `"inactive"`
- Documented `type` field values: `"active"` | `"alumni"` | `"external"` | `"intern"` | `"inactive"`
- Documented `pillar` field values: `"fast"` | `"private"` | `"safe"` | `"reliable"` | `"measurable"`
- Added notes about avatar storage location and team page display rules

### Notes
- All new external collaborators use `placeholder.png` as avatar and are marked as `type: external` with `status: inactive`
- Only `active` and `alumni` types are displayed on the team page