### PR TITLE
Fixes typo on the Philosophy page

### DIFF
--- a/src/pages/philosophy.astro
+++ b/src/pages/philosophy.astro
@@ -34,7 +34,7 @@ import HeaderPhilosophy from "@/components/HeaderPhilosophy.astro"
   <Section>
     <NarrowContent>
       <div class="pt-10">
-        <h2 class="heading-label mb-4">Open collaboration, open standah2s, and open source</h2>
+        <h2 class="heading-label mb-4">Open collaboration, open standards, and open source</h2>
 
         <p>Cloudflare’s massive popularity puts us in a very privileged position. We can research, implement and deploy experiments at a scale that simply can’t be done by most organizations. This makes Cloudflare an attractive research partner for universities and other research institutions who have domain knowledge but not data. We rely on our own expertise along with that of peers in both academia and industry to decide which problems to tackle in order to achieve common goals and make new scientific progress. Our middlebox detection project proposed by researchers at the University of Michigan, is an example of such a problem. Further engagements with academia are also facilitated by our recurrent internship opportunities.</p>
 


### PR DESCRIPTION
Before:
<img width="1104" height="308" alt="CleanShot 2026-04-24 at 14 43 53@2x" src="https://github.com/user-attachments/assets/2c582c9b-2e1f-4856-87b1-92ca05f32fb5" />

After:
Says "Open collaboration, open standards, and open source"