### PR TITLE
Fixes "missing" blog posts

### DIFF
--- a/content/people/abe-carryl.md
+++ b/content/people/abe-carryl.md
@@ -1,0 +1,14 @@
+---
+title: Abe Carryl
+position: Product Manager
+twitter: mrlincolnlogs
+avatar: placeholder.png
+slug: abe-carryl
+type: external
+---
+
+Abe Carryl is a product manager at Cloudflare working on Zero Trust and Cloudflare Tunnel.
+
+## Research Areas
+
+Zero Trust, Networking, Infrastructure

--- a/content/people/alex-chen.md
+++ b/content/people/alex-chen.md
@@ -1,0 +1,14 @@
+---
+title: Alex Chen
+position: Research Engineer
+twitter: alexchenhz
+avatar: placeholder.png
+slug: alex-chen
+type: external
+---
+
+Alex Chen is a research engineer at Cloudflare working on threat intelligence and detection systems.
+
+## Research Areas
+
+Threat Intelligence, Bot Detection, Network Measurement

--- a/content/people/apoorv-kothari.md
+++ b/content/people/apoorv-kothari.md
@@ -1,0 +1,13 @@
+---
+title: Apoorv Kothari
+position: Research Engineer
+avatar: placeholder.png
+slug: apoorv-kothari
+type: external
+---
+
+Apoorv Kothari is a research engineer at Cloudflare working on network protocols and security.
+
+## Research Areas
+
+Network Protocols, DDoS, QUIC

--- a/content/people/carlos-rodrigues.md
+++ b/content/people/carlos-rodrigues.md
@@ -1,0 +1,13 @@
+---
+title: Carlos Rodrigues
+position: Research Engineer
+avatar: placeholder.png
+slug: carlos-rodrigues
+type: external
+---
+
+Carlos Rodrigues is a research engineer at Cloudflare working on Internet measurement and network performance.
+
+## Research Areas
+
+Internet Measurement, Performance, Network Quality

--- a/content/people/chris-branch.md
+++ b/content/people/chris-branch.md
@@ -1,0 +1,13 @@
+---
+title: Chris Branch
+position: Software Engineer
+avatar: placeholder.png
+slug: chris-branch
+type: external
+---
+
+Chris Branch is a software engineer at Cloudflare working on networking and VPN technologies.
+
+## Research Areas
+
+Networking, VPN, Network Protocols

--- a/content/people/david-belson.md
+++ b/content/people/david-belson.md
@@ -1,0 +1,14 @@
+---
+title: David Belson
+position: Head of Data Insight
+twitter: dbelson
+avatar: placeholder.png
+slug: david-belson
+type: external
+---
+
+David Belson is Head of Data Insight at Cloudflare, focused on Internet traffic and connectivity trends, performance, and security insights.
+
+## Research Areas
+
+Internet Measurement, Traffic Analysis, Network Resilience

--- a/content/people/dina-kozlov.md
+++ b/content/people/dina-kozlov.md
@@ -1,0 +1,14 @@
+---
+title: Dina Kozlov
+position: Product Manager
+twitter: dinasaur_404
+avatar: placeholder.png
+slug: dina-kozlov
+type: external
+---
+
+Dina Kozlov is a product manager at Cloudflare working on networking and connectivity products.
+
+## Research Areas
+
+Networking, Connectivity, Internet Infrastructure

--- a/content/people/kenton-varda.md
+++ b/content/people/kenton-varda.md
@@ -1,0 +1,14 @@
+---
+title: Kenton Varda
+position: Tech Lead, Cloudflare Workers
+twitter: kentonvarda
+avatar: placeholder.png
+slug: kenton-varda
+type: external
+---
+
+Kenton Varda is the tech lead for Cloudflare Workers, focused on the security and performance of the Workers runtime.
+
+## Research Areas
+
+Systems Security, Isolation, WebAssembly

--- a/content/people/lai-yi-ohlsen.md
+++ b/content/people/lai-yi-ohlsen.md
@@ -1,0 +1,13 @@
+---
+title: Lai Yi Ohlsen
+position: Research Engineer
+avatar: placeholder.png
+slug: lai-yi-ohlsen
+type: external
+---
+
+Lai Yi Ohlsen is a research engineer at Cloudflare focused on Internet measurement and network quality.
+
+## Research Areas
+
+Internet Measurement, Network Quality, Performance

--- a/content/people/lenka-marekova.md
+++ b/content/people/lenka-marekova.md
@@ -1,0 +1,13 @@
+---
+title: Lenka Mareková
+position: Security Engineer
+avatar: placeholder.png
+slug: lenka-marekova
+type: external
+---
+
+Lenka Mareková is a security engineer at Cloudflare working on infrastructure security and cryptography.
+
+## Research Areas
+
+Security, Cryptography, Infrastructure

--- a/content/people/louis-navarre.md
+++ b/content/people/louis-navarre.md
@@ -1,0 +1,13 @@
+---
+title: Louis Navarre
+position: Guest Author
+avatar: placeholder.png
+slug: louis-navarre
+type: external
+---
+
+Louis Navarre is a researcher at UCLouvain working on network protocols and DDoS defense.
+
+## Research Areas
+
+Network Protocols, DDoS, QUIC

--- a/content/people/sofia-celi.md
+++ b/content/people/sofia-celi.md
@@ -1,0 +1,14 @@
+---
+title: Sofía Celi
+position: Cryptography Researcher
+twitter: claucece
+avatar: placeholder.png
+slug: sofia-celi
+type: external
+---
+
+Sofía Celi is a cryptography researcher and implementer at Cloudflare, working on post-quantum cryptography and privacy-enhancing technologies.
+
+## Research Areas
+
+Cryptography, Post-Quantum Cryptography, Privacy

--- a/src/data/blog-mappings.ts
+++ b/src/data/blog-mappings.ts
@@ -5,6 +5,18 @@ export interface BlogMapping {
 }
 
 export const blogMappings: Record<string, BlogMapping> = {
+  "http://blog.cloudflare.com/past-bots-and-humans": {
+    author: "thibault-meunier",
+  },
+  "http://blog.cloudflare.com/unweight-tensor-compression": {
+    author: "mari-galicer",
+  },
+  "http://blog.cloudflare.com/rethinking-cache-ai-humans": {
+    author: "suleman-ahmad",
+  },
+  "http://blog.cloudflare.com/radar-origin-pq-key-transparency-aspa": {
+    author: "thibault-meunier",
+  },
   "http://blog.cloudflare.com/react2shell-rsc-vulnerabilities-exploitation-threat-brief":
     {
       pillar: "safe",
@@ -12,396 +24,491 @@ export const blogMappings: Record<string, BlogMapping> = {
     },
   "http://blog.cloudflare.com/fresh-insights-from-old-data-corroborating-reports-of-turkmenistan-ip":
     {
+      author: "luke-valenta",
       pillar: "measurable",
       tags: ["censorship", "measurement"],
     },
   "http://blog.cloudflare.com/agent-registry": {
+    author: "thibault-meunier",
     pillar: "private",
     tags: ["privacy", "bots"],
   },
   "http://blog.cloudflare.com/private-rate-limiting": {
+    author: "thibault-meunier",
     pillar: "private",
     tags: ["privacy", "cryptography"],
   },
   "http://blog.cloudflare.com/measuring-network-connections-at-scale": {
+    author: "suleman-ahmad",
     pillar: "measurable",
     tags: ["measurement", "TCP"],
   },
   "http://blog.cloudflare.com/detecting-cgn-to-reduce-collateral-damage": {
+    author: "vasilis-giotsas",
     pillar: "measurable",
     tags: ["measurement", "IPv4"],
   },
   "http://blog.cloudflare.com/how-to-build-your-own-vpn-or-the-history-of-warp":
     {
+      author: "chris-branch",
       pillar: "private",
       tags: ["VPN", "privacy"],
     },
   "http://blog.cloudflare.com/defending-quic-from-acknowledgement-based-ddos-attacks":
     {
+      author: "apoorv-kothari",
       pillar: "safe",
       tags: ["security", "DDoS", "quic"],
     },
   "http://blog.cloudflare.com/so-long-and-thanks-for-all-the-fish-how-to-escape-the-linux-networking-stack":
     {
+      author: "thibault-meunier",
       pillar: "fast",
       tags: ["performance", "networking"],
     },
   "http://blog.cloudflare.com/pq-2025": {
+    author: "bas-westerbaan",
     pillar: "private",
     tags: ["post-quantum", "cryptography"],
   },
   "http://blog.cloudflare.com/bootstrap-mtc": {
+    author: "luke-valenta",
     pillar: "private",
     tags: ["cryptography", "privacy"],
   },
   "http://blog.cloudflare.com/a-framework-for-measuring-internet-resilience": {
+    author: "vasilis-giotsas",
     pillar: "measurable",
     tags: ["measurement", "resilience"],
   },
   "http://blog.cloudflare.com/tricky-internet-measurement": {
+    author: "marwan-fayed",
     pillar: "measurable",
     tags: ["measurement"],
   },
   "http://blog.cloudflare.com/introducing-tld-insights-on-cloudflare-radar": {
+    author: "david-belson",
     pillar: "measurable",
     tags: ["measurement", "DNS"],
   },
   "http://blog.cloudflare.com/experience-of-data-at-scale": {
+    author: "marwan-fayed",
     pillar: "measurable",
     tags: ["data", "analytics"],
   },
   "http://blog.cloudflare.com/evolution-of-cloudflare-radar": {
+    author: "david-belson",
     pillar: "measurable",
     tags: ["measurement", "analytics"],
   },
   "http://blog.cloudflare.com/internet-measurement-resilience-transparency-week":
     {
+      author: "mari-galicer",
       pillar: "measurable",
       tags: ["measurement", "transparency"],
     },
   "http://blog.cloudflare.com/how-does-cloudflares-speed-test-really-work": {
+    author: "lai-yi-ohlsen",
     pillar: "fast",
     tags: ["performance", "measurement"],
   },
   "http://blog.cloudflare.com/improving-the-trustworthiness-of-javascript-on-the-web":
     {
+      author: "michael-rosenberg",
       pillar: "safe",
       tags: ["security", "javascript"],
     },
   "http://blog.cloudflare.com/automatically-secure": {
+    author: "suleman-ahmad",
     pillar: "safe",
     tags: ["security", "automation"],
   },
   "http://blog.cloudflare.com/you-dont-need-quantum-hardware": {
+    author: "luke-valenta",
     pillar: "private",
     tags: ["post-quantum", "cryptography"],
   },
   "http://blog.cloudflare.com/verified-bots-with-cryptography": {
+    author: "mari-galicer",
     pillar: "private",
     tags: ["cryptography", "bots"],
   },
   "http://blog.cloudflare.com/orange-me2eets-we-made-an-end-to-end-encrypted-video-calling-app-and-it-was":
     {
+      author: "mari-galicer",
       pillar: "private",
       tags: ["encryption", "privacy"],
     },
   "http://blog.cloudflare.com/web-bot-auth": {
+    author: "thibault-meunier",
     pillar: "safe",
     tags: ["security", "bots"],
   },
   "http://blog.cloudflare.com/azul-certificate-transparency-log": {
+    author: "luke-valenta",
     pillar: "safe",
     tags: ["security", "certificates"],
   },
   "http://blog.cloudflare.com/open-sourcing-openpubkey-ssh-opkssh-integrating-single-sign-on-with-ssh":
     {
+      author: "ethan-heilman",
       pillar: "safe",
       tags: ["security", "SSH"],
     },
   "http://blog.cloudflare.com/lattice-crypto-primer": {
+    author: "christopher-patton",
     pillar: "private",
     tags: ["cryptography", "post-quantum"],
   },
   "http://blog.cloudflare.com/https-only-for-cloudflare-apis-shutting-the-door-on-cleartext-traffic":
     {
+      author: "suleman-ahmad",
       pillar: "safe",
       tags: ["security", "encryption"],
     },
   "http://blog.cloudflare.com/an-early-look-at-cryptographic-watermarks-for-ai-generated-content":
     {
+      author: "christopher-patton",
       pillar: "private",
       tags: ["cryptography", "AI"],
     },
   "http://blog.cloudflare.com/post-quantum-zero-trust": {
+    author: "wesley-evans",
     pillar: "private",
     tags: ["post-quantum", "zero-trust"],
   },
   "http://blog.cloudflare.com/sometimes-i-cache": {
+    author: "thibault-meunier",
     pillar: "fast",
     tags: ["performance", "caching"],
   },
   "http://blog.cloudflare.com/topaz-policy-engine-design": {
+    author: "suleman-ahmad",
     pillar: "safe",
     tags: ["security", "DNS"],
   },
   "http://blog.cloudflare.com/another-look-at-pq-signatures": {
+    author: "bas-westerbaan",
     pillar: "private",
     tags: ["post-quantum", "cryptography"],
   },
   "http://blog.cloudflare.com/introducing-speed-brain": {
+    author: "suleman-ahmad",
     pillar: "fast",
     tags: ["performance", "optimization"],
   },
   "http://blog.cloudflare.com/key-transparency": {
+    author: "thibault-meunier",
     pillar: "private",
     tags: ["cryptography", "transparency"],
   },
   "http://blog.cloudflare.com/connection-tampering": {
+    author: "luke-valenta",
     pillar: "measurable",
     tags: ["measurement", "security"],
   },
   "http://blog.cloudflare.com/tcp-resets-timeouts": {
+    author: "luke-valenta",
     pillar: "measurable",
     tags: ["measurement", "TCP"],
   },
   "http://blog.cloudflare.com/nists-first-post-quantum-standards": {
+    author: "bas-westerbaan",
     pillar: "private",
     tags: ["post-quantum", "standards"],
   },
   "http://blog.cloudflare.com/introducing-automatic-ssl-tls-securing-and-simplifying-origin-connectivity":
     {
+      author: "suleman-ahmad",
       pillar: "safe",
       tags: ["security", "SSL"],
     },
   "http://blog.cloudflare.com/harnessing-office-chaos": {
+    author: "thibault-meunier",
     pillar: "private",
     tags: ["cryptography", "randomness"],
   },
   "http://blog.cloudflare.com/pq-2024": {
+    author: "bas-westerbaan",
     pillar: "private",
     tags: ["post-quantum", "cryptography"],
   },
   "http://blog.cloudflare.com/privacy-pass-standard": {
+    author: "thibault-meunier",
     pillar: "private",
     tags: ["privacy", "standards"],
   },
   "http://blog.cloudflare.com/have-your-data-and-hide-it-too-an-introduction-to-differential-privacy":
     {
+      author: "avani-wildani",
       pillar: "private",
       tags: ["privacy", "differential-privacy"],
     },
   "http://blog.cloudflare.com/birthday-week-2023-wrap-up": {
+    author: "dina-kozlov",
     pillar: "measurable",
     tags: ["announcements"],
   },
   "http://blog.cloudflare.com/post-quantum-cryptography-ga": {
+    author: "wesley-evans",
     pillar: "private",
     tags: ["post-quantum", "cryptography"],
   },
   "http://blog.cloudflare.com/announcing-encrypted-client-hello": {
+    author: "christopher-wood",
     pillar: "private",
     tags: ["privacy", "encryption"],
   },
   "http://blog.cloudflare.com/post-quantum-to-origins": {
+    author: "suleman-ahmad",
     pillar: "private",
     tags: ["post-quantum", "cryptography"],
   },
   "http://blog.cloudflare.com/deep-dive-privacy-preserving-measurement": {
+    author: "mari-galicer",
     pillar: "private",
     tags: ["privacy", "measurement"],
   },
   "http://blog.cloudflare.com/connection-coalescing-with-origin-frames-fewer-dns-queries-fewer-connections":
     {
+      author: "suleman-ahmad",
       pillar: "fast",
       tags: ["performance", "optimization"],
     },
   "http://blog.cloudflare.com/post-quantum-crypto-should-be-free": {
+    author: "bas-westerbaan",
     pillar: "private",
     tags: ["post-quantum", "cryptography"],
   },
   "http://blog.cloudflare.com/kyber-isnt-broken": {
+    author: "bas-westerbaan",
     pillar: "private",
     tags: ["post-quantum", "cryptography"],
   },
   "http://blog.cloudflare.com/inside-geo-key-manager-v2": {
+    author: "tanya-verma",
     pillar: "safe",
     tags: ["security", "key-management"],
   },
   "http://blog.cloudflare.com/stronger-than-a-promise-proving-oblivious-http-privacy-properties":
     {
+      author: "christopher-wood",
       pillar: "private",
       tags: ["privacy", "cryptography"],
     },
   "http://blog.cloudflare.com/post-quantum-for-all": {
+    author: "bas-westerbaan",
     pillar: "private",
     tags: ["post-quantum", "cryptography"],
   },
   "http://blog.cloudflare.com/securing-origin-connectivity": {
+    author: "suleman-ahmad",
     pillar: "safe",
     tags: ["security", "SSL"],
   },
   "http://blog.cloudflare.com/post-quantum-tunnel": {
+    author: "bas-westerbaan",
     pillar: "private",
     tags: ["post-quantum", "cryptography"],
   },
   "http://blog.cloudflare.com/deep-dives-how-the-internet-works": {
+    author: "nick-sullivan",
     pillar: "measurable",
     tags: ["education"],
   },
   "http://blog.cloudflare.com/experiment-with-pq": {
+    author: "bas-westerbaan",
     pillar: "private",
     tags: ["post-quantum", "cryptography"],
   },
   "http://blog.cloudflare.com/nist-post-quantum-surprise": {
+    author: "bas-westerbaan",
     pillar: "private",
     tags: ["post-quantum", "standards"],
   },
   "http://blog.cloudflare.com/hertzbleed-explained": {
+    author: "armando-faz",
     pillar: "safe",
     tags: ["security", "vulnerabilities"],
   },
   "http://blog.cloudflare.com/next-gen-web3-network": {
+    author: "wesley-evans",
     pillar: "reliable",
     tags: ["web3", "infrastructure"],
   },
   "http://blog.cloudflare.com/cloudflare-pages-on-ipfs": {
+    author: "thibault-meunier",
     pillar: "reliable",
     tags: ["web3", "IPFS"],
   },
   "http://blog.cloudflare.com/ipfs-measurements": {
+    author: "thibault-meunier",
     pillar: "measurable",
     tags: ["measurement", "web3"],
   },
   "http://blog.cloudflare.com/breaking-down-broadband-nutrition-labels": {
+    author: "kristin-berdan",
     pillar: "measurable",
     tags: ["measurement", "transparency"],
   },
   "http://blog.cloudflare.com/future-proofing-saltstack": {
+    author: "lenka-marekova",
     pillar: "safe",
     tags: ["security", "infrastructure"],
   },
   "http://blog.cloudflare.com/unlocking-quic-proxying-potential": {
+    author: "christopher-wood",
     pillar: "fast",
     tags: ["performance", "quic"],
   },
   "http://blog.cloudflare.com/a-primer-on-proxies": {
+    author: "christopher-wood",
     pillar: "fast",
     tags: ["performance", "proxies"],
   },
   "http://blog.cloudflare.com/announcing-ddr-support": {
+    author: "christopher-wood",
     pillar: "private",
     tags: ["privacy", "DNS"],
   },
   "http://blog.cloudflare.com/post-quantum-future": {
+    author: "nick-sullivan",
     pillar: "private",
     tags: ["post-quantum", "cryptography"],
   },
   "http://blog.cloudflare.com/post-quantumify-cloudflare": {
+    author: "thom-wiggers",
     pillar: "private",
     tags: ["post-quantum", "cryptography"],
   },
   "http://blog.cloudflare.com/hybrid-public-key-encryption": {
+    author: "christopher-wood",
     pillar: "private",
     tags: ["cryptography", "encryption"],
   },
   "http://blog.cloudflare.com/post-quantum-formal-analysis": {
+    author: "jonathan-hoyland",
     pillar: "private",
     tags: ["post-quantum", "cryptography"],
   },
   "http://blog.cloudflare.com/post-quantum-easycrypt-jasmin": {
+    author: "manuel-barbosa",
     pillar: "private",
     tags: ["post-quantum", "cryptography"],
   },
   "http://blog.cloudflare.com/making-protocols-post-quantum": {
+    author: "thom-wiggers",
     pillar: "private",
     tags: ["post-quantum", "protocols"],
   },
   "http://blog.cloudflare.com/post-quantum-key-encapsulation": {
+    author: "goutam-tamvada",
     pillar: "private",
     tags: ["post-quantum", "cryptography"],
   },
   "http://blog.cloudflare.com/post-quantum-signatures": {
+    author: "goutam-tamvada",
     pillar: "private",
     tags: ["post-quantum", "cryptography"],
   },
   "http://blog.cloudflare.com/post-quantum-taxonomy": {
+    author: "sofia-celi",
     pillar: "private",
     tags: ["post-quantum", "cryptography"],
   },
   "http://blog.cloudflare.com/quantum-solace-and-spectre": {
+    author: "sofia-celi",
     pillar: "private",
     tags: ["post-quantum", "cryptography"],
   },
   "http://blog.cloudflare.com/sizing-up-post-quantum-signatures": {
+    author: "bas-westerbaan",
     pillar: "private",
     tags: ["post-quantum", "cryptography"],
   },
   "http://blog.cloudflare.com/observe-and-manage-cloudflare-tunnel": {
+    author: "abe-carryl",
     pillar: "reliable",
     tags: ["infrastructure", "tunnel"],
   },
   "http://blog.cloudflare.com/cdn-latency-passive-measurement": {
+    author: "vasilis-giotsas",
     pillar: "measurable",
     tags: ["measurement", "performance"],
   },
   "http://blog.cloudflare.com/multi-user-ip-address-detection": {
+    author: "alex-chen",
     pillar: "measurable",
     tags: ["measurement", "detection"],
   },
   "http://blog.cloudflare.com/scaling-geo-key-manager": {
+    author: "tanya-verma",
     pillar: "reliable",
     tags: ["infrastructure", "key-management"],
   },
   "http://blog.cloudflare.com/privacy-preserving-compromised-credential-checking":
     {
+      author: "luke-valenta",
       pillar: "private",
       tags: ["privacy", "security"],
     },
   "http://blog.cloudflare.com/addressing-agility": {
+    author: "marwan-fayed",
     pillar: "reliable",
     tags: ["networking", "infrastructure"],
   },
   "http://blog.cloudflare.com/research-directions-in-password-security": {
+    author: "tara-whalen",
     pillar: "safe",
     tags: ["security", "passwords"],
   },
   "http://blog.cloudflare.com/cloudflare-and-the-ietf": {
+    author: "jonathan-hoyland",
     pillar: "measurable",
     tags: ["standards", "collaboration"],
   },
   "http://blog.cloudflare.com/circl-pairings-update": {
+    author: "watson-ladd",
     pillar: "private",
     tags: ["cryptography"],
   },
   "http://blog.cloudflare.com/exported-authenticators-the-long-road-to-rfc": {
+    author: "jonathan-hoyland",
     pillar: "safe",
     tags: ["security", "standards"],
   },
   "http://blog.cloudflare.com/connection-coalescing-experiments": {
+    author: "suleman-ahmad",
     pillar: "fast",
     tags: ["performance", "optimization"],
   },
   "http://blog.cloudflare.com/ssl-tls-recommender": {
+    author: "suleman-ahmad",
     pillar: "safe",
     tags: ["security", "SSL"],
   },
   "http://blog.cloudflare.com/spectre-research-with-tu-graz": {
+    author: "kenton-varda",
     pillar: "safe",
     tags: ["security", "research"],
   },
   "http://blog.cloudflare.com/handshake-encryption-endgame-an-ech-update": {
+    author: "christopher-wood",
     pillar: "private",
     tags: ["privacy", "encryption"],
   },
   "http://blog.cloudflare.com/privacy-pass-v3": {
+    author: "armando-faz",
     pillar: "private",
     tags: ["privacy"],
   },
   "http://blog.cloudflare.com/announcing-cloudflare-research-hub": {
+    author: "thibault-meunier",
     pillar: "measurable",
     tags: ["research"],
   },
   "http://blog.cloudflare.com/internship-experience-research-engineer": {
+    author: "thibault-meunier",
     pillar: "measurable",
     tags: ["research"],
   },

--- a/src/loaders/blog.ts
+++ b/src/loaders/blog.ts
@@ -77,7 +77,7 @@ function getBlogAuthorMap(): Record<string, string> {
   const map: Record<string, string> = {};
   if (!fs.existsSync(PEOPLE_DIR)) return map;
 
-  const files = fs.readdirSync(PEOPLE_DIR).filter(f => f.endsWith(".md"));
+  const files = fs.readdirSync(PEOPLE_DIR).filter((f) => f.endsWith(".md"));
   for (const file of files) {
     const content = fs.readFileSync(path.join(PEOPLE_DIR, file), "utf-8");
     const blogAuthorMatch = content.match(/^blog_author:\s*(.+)$/m);
@@ -145,7 +145,9 @@ export function blogLoader(): Loader {
               `blogposts_${blogAuthor}.json`
             );
           } catch (err) {
-            logger.warn(`Failed to fetch posts for author "${blogAuthor}": ${err}`);
+            logger.warn(
+              `Failed to fetch posts for author "${blogAuthor}": ${err}`
+            );
             continue;
           }
 
@@ -177,7 +179,9 @@ export function blogLoader(): Loader {
         }
 
         if (extraCount > 0) {
-          logger.info(`Loaded ${extraCount} additional blog posts from per-author endpoints`);
+          logger.info(
+            `Loaded ${extraCount} additional blog posts from per-author endpoints`
+          );
         }
       } catch (error) {
         logger.error(`Failed to load blog posts: ${error}`);

--- a/src/loaders/blog.ts
+++ b/src/loaders/blog.ts
@@ -4,6 +4,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { blogMappings } from "../data/blog-mappings";
 
+const PEOPLE_DIR = "./content/people";
+
 const WORKER_BASE_URL = "https://website-worker.research.cloudflare.com";
 const CACHE_DIR = ".astro/cache/blog";
 
@@ -69,6 +71,25 @@ async function fetchWithCache(
 }
 
 /**
+ * Reads all people files and returns a map of blog_author -> people slug
+ */
+function getBlogAuthorMap(): Record<string, string> {
+  const map: Record<string, string> = {};
+  if (!fs.existsSync(PEOPLE_DIR)) return map;
+
+  const files = fs.readdirSync(PEOPLE_DIR).filter(f => f.endsWith(".md"));
+  for (const file of files) {
+    const content = fs.readFileSync(path.join(PEOPLE_DIR, file), "utf-8");
+    const blogAuthorMatch = content.match(/^blog_author:\s*(.+)$/m);
+    const slugMatch = content.match(/^slug:\s*(.+)$/m);
+    if (blogAuthorMatch && slugMatch) {
+      map[blogAuthorMatch[1].trim()] = slugMatch[1].trim();
+    }
+  }
+  return map;
+}
+
+/**
  * Custom Astro loader for Cloudflare blog posts
  */
 export function blogLoader(): Loader {
@@ -84,14 +105,14 @@ export function blogLoader(): Loader {
         // Clear existing entries
         store.clear();
 
-        // Process each blog post
+        // Track which URLs we've already added
+        const seenLinks = new Set<string>();
+
+        // Process each blog post from /blog/all
         for (const post of posts) {
           const id = generateDigest(post.link);
-
-          // Get mapping data for this blog post
           const mapping = blogMappings[post.link];
 
-          // Parse and validate the data
           const data = await parseData({
             id,
             data: {
@@ -106,13 +127,58 @@ export function blogLoader(): Loader {
             },
           });
 
-          store.set({
-            id,
-            data,
-          });
+          store.set({ id, data });
+          seenLinks.add(post.link);
         }
 
-        logger.info(`Loaded ${posts.length} blog posts`);
+        logger.info(`Loaded ${posts.length} blog posts from /blog/all`);
+
+        // Fetch per-author posts to catch any not in /blog/all
+        const blogAuthorMap = getBlogAuthorMap();
+        let extraCount = 0;
+
+        for (const [blogAuthor, peopleSlug] of Object.entries(blogAuthorMap)) {
+          let authorPosts: BlogPost[];
+          try {
+            authorPosts = await fetchWithCache(
+              `/blog/author?name=${blogAuthor}`,
+              `blogposts_${blogAuthor}.json`
+            );
+          } catch (err) {
+            logger.warn(`Failed to fetch posts for author "${blogAuthor}": ${err}`);
+            continue;
+          }
+
+          for (const post of authorPosts) {
+            if (seenLinks.has(post.link)) continue;
+
+            const id = generateDigest(post.link);
+            const mapping = blogMappings[post.link];
+
+            const data = await parseData({
+              id,
+              data: {
+                title: post.heading,
+                date: new Date(post.date),
+                url: post.link,
+                excerpt: post.text,
+                image: post.image,
+                // Use mapping author if set, otherwise fall back to this person
+                author: mapping?.author ?? peopleSlug,
+                pillar: mapping?.pillar,
+                tags: mapping?.tags,
+              },
+            });
+
+            store.set({ id, data });
+            seenLinks.add(post.link);
+            extraCount++;
+          }
+        }
+
+        if (extraCount > 0) {
+          logger.info(`Loaded ${extraCount} additional blog posts from per-author endpoints`);
+        }
       } catch (error) {
         logger.error(`Failed to load blog posts: ${error}`);
         throw error;

--- a/src/pages/people/[slug].astro
+++ b/src/pages/people/[slug].astro
@@ -29,6 +29,20 @@ const htmlContent = person.rendered?.html || '';
 const personPublications = await getCollection('publications', (pub) => {
   return pub.data.authors?.some(author => author.id === slug);
 });
+
+// Get all blog posts where this person is the author
+const personBlogPosts = await getCollection('blog', (post) => {
+  return post.data.author?.id === slug;
+});
+
+console.log({ personBlogPosts });
+
+// Combine and sort by date descending
+const allContent = [...personPublications, ...personBlogPosts].sort((a, b) => {
+  const dateA = a.data.date ? new Date(a.data.date).getTime() : 0;
+  const dateB = b.data.date ? new Date(b.data.date).getTime() : 0;
+  return dateB - dateA;
+});
 ---
 
 <InteriorLayout metaTitle={person.data.title}>
@@ -57,6 +71,6 @@ const personPublications = await getCollection('publications', (pub) => {
       </div>
     </NarrowContent>
 
-    <div class="border-t border-page-border"><ArticleGrid publications={personPublications} showFilters={false} /></div>
+    <div class="border-t border-page-border"><ArticleGrid publications={allContent} showFilters={false} /></div>
   </Section>
 </InteriorLayout>


### PR DESCRIPTION
### Problem
The people profile pages (/people/[slug]) were only displaying academic publications, not blog posts. 

### Solution
**Wiring up blog posts to profile pages**
- Updated [slug].astro to query the blog collection for posts where author.id matches the person's slug, then merge and sort publications and blog posts together by date descending before passing them to ArticleGrid (which already supported both collection types).

**Populating author metadata**
- Added author fields to all 100 entries in blog-mappings.ts by scraping each blog post page and matching author names against the people collection. 87 posts were matched automatically; the remaining 13 were resolved manually via the Ghost CMS JSON embedded in each page's HTML.
- Created 12 new people files for authors who had blog posts but no existing profile (e.g. david-belson, sofia-celi, kenton-varda), marked as type: external.
- Added 4 new blog-mappings.ts entries for recent posts that weren't yet in the file.

**Fetching older posts beyond the 100-post cap**
- Updated the blogLoader to also fetch from the per-author /blog/author?name=<blog_author> endpoint for every person in the people collection who has a blog_author field set. Any posts returned that aren't already in the collection are merged in, with the author assigned automatically. This added 102 additional posts on first run and ensures authors have their full post history surfaced.