### PR TITLE
Fixes badge wrapping

### DIFF
--- a/src/components/Badge.astro
+++ b/src/components/Badge.astro
@@ -2,7 +2,7 @@
 import { cva, type VariantProps } from "class-variance-authority";
 
 const badgeClassNames = cva(
-  "inline-block border font-mono leading-6 px-2 rounded-[4px] font-mono text-xs",
+  "inline-block border font-mono leading-6 px-2 rounded-[4px] font-mono text-xs whitespace-nowrap",
   {
     variants: {
       variant: {

--- a/src/components/home/WhatsNewCard.astro
+++ b/src/components/home/WhatsNewCard.astro
@@ -22,7 +22,7 @@ const { className, title, date, link, tags } = Astro.props as Props;
     <div class="mb-10"><slot /></div>
   </div>
   { tags && (
-    <div class="mt-auto flex gap-1 items-center">
+    <div class="mt-auto flex gap-1 items-center flex-wrap">
       {tags.map(tag => (
         <Badge variant="blue">{tag}</Badge>
       ))}


### PR DESCRIPTION
Previously: text was wrapping within a tag. I updated the CSS so the text wouldn't wrap but the tags themselves will.

| Before | After |
| :---: | :---: |
| <img width="359" height="293" alt="CleanShot 2026-05-06 at 15 39 18" src="https://github.com/user-attachments/assets/15a4e872-aa65-497c-8b5c-272fbdd62b9e" /> |  <img width="367" height="286" alt="CleanShot 2026-05-06 at 15 45 11" src="https://github.com/user-attachments/assets/5541fea0-f76f-4390-8ec7-08037ec53e86" /> |
