### PR TITLE
fix: add title attributes to nav links and remove description truncation

### DIFF
--- a/src/components/NavigationMenu.tsx
+++ b/src/components/NavigationMenu.tsx
@@ -242,12 +242,12 @@ function ListItem({
   return (
     <li {...props}>
       <NavigationMenuLink asChild>
-        <a href={href} className="group/subnav subnav">
+        <a href={href} title={title} className="group/subnav subnav">
           <div className="text-sm leading-none font-medium subnav-title">
             {title}
           </div>
           {children && (
-            <p className="text-muted-foreground line-clamp-2 text-sm leading-snug">
+            <p className="text-muted-foreground text-sm leading-snug">
               {children}
             </p>
           )}


### PR DESCRIPTION
Two small fixes to the Focus Areas navigation menu.

- Added `title` attributes to all focus area links in the subnav to improve SEO Lighthouse score — links previously had no descriptive text beyond "See More"
- Removed `line-clamp-2` from focus area descriptions so they display in full instead of being cut off mid-sentence