### PR TITLE
fix: show full publication date on blog post cards

### DIFF
--- a/src/components/BlogPostCard.astro
+++ b/src/components/BlogPostCard.astro
@@ -12,12 +12,13 @@ const { post } = Astro.props;
 const dataTags = Astro.props["data-tags"];
 
 const year = post.data.date.getFullYear().toString();
+const dateStr = post.data.date.toISOString().split('T')[0];
 const tags = post.data.tags?.map(t => t.id) || [];
 ---
 
 <article class="p-8 flex flex-col justify-between article-card" data-tags={dataTags}>
   <div class="flex-1">
-    <ArticleHeading type="blog" date="" year={year} />
+    <ArticleHeading type="blog" date={dateStr} year={year} />
 
     <!-- title -->
     <h3 class="leading-snug text-lg font-medium text-bizarre title">


### PR DESCRIPTION
Blog post cards were only showing the year (e.g. "2025") instead of the full date. The full date was available from the blog loader but wasn't being passed to ArticleHeading.

Formats the date as YYYY-MM-DD and passes it through so ArticleHeading displays the full date (e.g. "October 30, 2025").

Publications are unaffected — they only have a year field so they continue showing just the year.