### PR TITLE
feat(theme): add light/dark mode toggle

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -10,10 +10,9 @@ import Icon from "./Icon.astro";
       <!-- Logo section -->
       <div class="sm:row-span-2 xl:row-span-1">
         <a href="/">
-          <picture>
-            <source srcset="/images/logo.svg" media="(prefers-color-scheme: dark)" />
-            <img src="/images/logo--light.svg" alt="Cloudflare Research" width="197" height="53" />
-          </picture>
+          {/* Two logos stacked — CSS picks the right one based on data-theme. */}
+          <img src="/images/logo--light.svg" alt="Cloudflare Research" class="theme-logo theme-logo--light" width="197" height="53" />
+          <img src="/images/logo.svg" alt="Cloudflare Research" class="theme-logo theme-logo--dark" width="197" height="53" />
         </a>
       </div>
 

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,20 +1,24 @@
 ---
 import { NavMenu } from "./NavigationMenu"
+import { ThemeToggle } from "./ThemeToggle"
 ---
 
 <div class="flex items-center justify-between py-4 px-3 sm:px-5">
   <div class="shrink-0">
     <a href="/">
-      <picture>
-        <source srcset="/images/logo.svg" media="(prefers-color-scheme: dark)" />
-        <img src="/images/logo--light.svg" alt="Cloudflare Research" class="h-8 sm:h-auto" width="191" height="32" />
-      </picture>
+      {/* Two logos stacked — CSS shows the right one based on data-theme on <html>.
+          See `.theme-logo--light` / `.theme-logo--dark` in global.css. */}
+      <img src="/images/logo--light.svg" alt="Cloudflare Research" class="theme-logo theme-logo--light h-8 sm:h-auto" width="191" height="32" />
+      <img src="/images/logo.svg" alt="Cloudflare Research" class="theme-logo theme-logo--dark h-8 sm:h-auto" width="191" height="32" />
     </a>
   </div>
   <nav class="flex-1 flex justify-end md:justify-end lg:justify-center">
     <NavMenu client:load />
   </nav>
-  <div class="hidden lg:block w-[197px] text-page-text text-right">
-    &nbsp;
+  <div class="hidden lg:flex w-[197px] items-center justify-end">
+    <ThemeToggle client:load />
+  </div>
+  <div class="lg:hidden">
+    <ThemeToggle client:load />
   </div>
 </div>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import * as React from "react";
+import { Sun, Moon } from "lucide-react";
+
+type Theme = "light" | "dark";
+
+const STORAGE_KEY = "theme";
+
+function getInitialTheme(): Theme {
+  if (typeof window === "undefined") return "light";
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored === "light" || stored === "dark") return stored;
+  } catch {
+    // localStorage blocked
+  }
+  // First visit — start from the user's OS preference so we don't surprise them.
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+export function ThemeToggle() {
+  const [theme, setTheme] = React.useState<Theme>("light");
+  const [mounted, setMounted] = React.useState(false);
+
+  // Initialise from localStorage / OS preference after mount.
+  React.useEffect(() => {
+    setTheme(getInitialTheme());
+    setMounted(true);
+  }, []);
+
+  function toggle() {
+    const next: Theme = theme === "light" ? "dark" : "light";
+    setTheme(next);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      // localStorage blocked
+    }
+    document.documentElement.dataset.theme = next;
+  }
+
+  // Render a placeholder until mounted to avoid hydration mismatch flicker.
+  if (!mounted) {
+    return (
+      <button
+        type="button"
+        aria-label="Toggle theme"
+        className="p-2 text-page-text hover:text-baby-blue-eyes transition-colors"
+      >
+        <Sun size={20} />
+      </button>
+    );
+  }
+
+  const label =
+    theme === "light" ? "Switch to dark mode" : "Switch to light mode";
+  const Icon = theme === "light" ? Moon : Sun;
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={label}
+      title={label}
+      className="p-2 text-page-text hover:text-baby-blue-eyes transition-colors"
+    >
+      <Icon size={20} />
+    </button>
+  );
+}

--- a/src/layouts/base.astro
+++ b/src/layouts/base.astro
@@ -14,6 +14,30 @@ const { metaTitle, metaDescription, bodyClassName = '' } = Astro.props;
 
 <html lang="en">
 	<head>
+		{/*
+			Theme bootstrap: runs synchronously before paint to prevent FOUC.
+			Reads the user's saved choice from localStorage (set by the toggle).
+			Valid values: "light" | "dark" | "system" (or null = system).
+			Sets data-theme="light" or data-theme="dark" on <html> so CSS can react.
+			When the choice is "system", we still resolve to a concrete value here
+			so styles only need to handle the two explicit states.
+		*/}
+		<script is:inline>
+			(function () {
+				try {
+					var stored = localStorage.getItem("theme");
+					var pref = stored === "light" || stored === "dark" ? stored : null;
+					var resolved =
+						pref ||
+						(window.matchMedia("(prefers-color-scheme: dark)").matches
+							? "dark"
+							: "light");
+					document.documentElement.dataset.theme = resolved;
+				} catch (e) {
+					// localStorage blocked — fall back to OS preference via CSS.
+				}
+			})();
+		</script>
 		<meta charset="utf-8" />
 		<link rel="icon" type="image/png" href="/favicon.png" />
 		<meta name="viewport" content="width=device-width" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8,9 +8,46 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* System preference-based dark mode */
+/* Dark mode shadcn vars — driven by the toggle (data-theme on <html>).
+   The inline script in base.astro always resolves "system" to "light" or "dark"
+   so we only need to react to those two values here. */
+:root[data-theme="dark"] {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.556 0 0);
+}
+
+/* Fallback for users with JS disabled — follows OS preference */
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme]) {
     --background: oklch(0.145 0 0);
     --foreground: oklch(0.985 0 0);
     --card: oklch(0.205 0 0);
@@ -228,16 +265,41 @@
   --badge-pink-bg: #fce7f3;
 }
 
-/* Dark mode semantic colors */
+/* Dark mode page semantic colors — driven by the toggle */
+:root[data-theme="dark"] {
+  --page-bg: #121212;
+  --page-text: #ffffff;
+  --page-text-muted: #989796;
+  --page-border: #2d2c2a;
+  --page-border-subtle: #353332;
+
+  --badge-blue-text: #4e84f7;
+  --badge-blue-bg: #0c1628;
+  --badge-purple-text: #8443f0;
+  --badge-purple-bg: #130a25;
+  --badge-green-text: #8cc560;
+  --badge-green-bg: #17210f;
+  --badge-orange-text: #ef6836;
+  --badge-orange-bg: #31190f;
+  --badge-white-text: #ffffff;
+  --badge-white-bg: #272727;
+  --badge-red-text: #ea336f;
+  --badge-red-bg: #260312;
+  --badge-yellow-text: #e9b46a;
+  --badge-yellow-bg: #261d11;
+  --badge-pink-text: #c441c6;
+  --badge-pink-bg: #160418;
+}
+
+/* Fallback for users with JS disabled — follows OS preference */
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme]) {
     --page-bg: #121212;
     --page-text: #ffffff;
     --page-text-muted: #989796;
     --page-border: #2d2c2a;
     --page-border-subtle: #353332;
 
-    /* Dark mode badge colors */
     --badge-blue-text: #4e84f7;
     --badge-blue-bg: #0c1628;
     --badge-purple-text: #8443f0;
@@ -391,13 +453,13 @@
     }
   }
 
-  /* Override logo in home header to always use dark logo */
-  #home-header picture source {
+  /* Override logo in home header to always use the white-text logo
+     (the home header has a blue background that needs white text in both themes). */
+  #home-header .theme-logo--light {
     display: none;
   }
-
-  #home-header picture img {
-    content: url("/images/logo.svg");
+  #home-header .theme-logo--dark {
+    display: inline-block;
   }
 
   /* Override navigation menu items in home header to always be white */
@@ -646,6 +708,27 @@
     /* prefers dark mode */
     @media (prefers-color-scheme: dark) {
       @apply bg-popover-foreground text-popover;
+    }
+  }
+
+  /* Theme-aware logo swap. Defaults assume light theme.
+     The data-theme attribute on <html> overrides. */
+  .theme-logo--dark {
+    display: none;
+  }
+  :root[data-theme="dark"] .theme-logo--light {
+    display: none;
+  }
+  :root[data-theme="dark"] .theme-logo--dark {
+    display: inline-block;
+  }
+  /* Fallback when JS is disabled — follow OS preference */
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme]) .theme-logo--light {
+      display: none;
+    }
+    :root:not([data-theme]) .theme-logo--dark {
+      display: inline-block;
     }
   }
 }


### PR DESCRIPTION
Adds a light/dark mode toggle button to the nav.

Changes:
- New `ThemeToggle` component (sun/moon icon, top-right of nav)
- User choice persists in `localStorage`; first-time visitors get their OS preference as the starting point
- Inline script in `<head>` sets `data-theme` on `<html>` before paint, so no flash of wrong theme
- Color CSS refactored to react to `[data-theme="dark"]` selector. The `@media (prefers-color-scheme: dark)` blocks are kept as a fallback for users with JS disabled.
- Nav logo and footer logo swap based on theme (previously tied to OS)
- Home header keeps the white-text logo in both modes (blue background)

Decorative image swaps (connectors, background patterns) still follow OS preference — happy to extend if reviewers want that.