### PR TITLE
feat(agent-ready): add Link headers and llms.txt for AI agent discoverability

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -56,3 +56,10 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: interest-cohort=()
+
+# Link headers for agent discovery (RFC 8288)
+# Tells AI agents where to find the sitemap and the LLM-friendly site index
+# without having to parse HTML first. Scored by isitagentready.com.
+/
+  Link: </sitemap-index.xml>; rel="sitemap"; type="application/xml"
+  Link: </llms.txt>; rel="alternate"; type="text/plain"; title="LLM-friendly site index"

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,27 @@
+# Cloudflare Research
+
+> Cloudflare Research explores the future of the Internet by bridging the gap between academic theory and real-world implementation. We work on cryptography, networking, security, privacy, and measurement to help build a better, more secure web.
+
+This file is an LLM-friendly site index following the llms.txt convention (https://llmstxt.org/). It lists the main sections of research.cloudflare.com so AI agents can quickly orient themselves without crawling the full HTML site.
+
+## Focus areas
+
+The team's work is organized into five areas. Each page describes the area in depth and links to related publications and blog posts.
+
+- [All Focus Areas](https://research.cloudflare.com/focus): Overview of the five research areas.
+- [More Private](https://research.cloudflare.com/focus/private): Privacy-preserving systems and protocols (Privacy Pass, anonymous credentials, DNS privacy, OHTTP).
+- [Safer](https://research.cloudflare.com/focus/safe): Production-quality security defenses against network interference and abuse, plus post-quantum cryptography.
+- [Faster](https://research.cloudflare.com/focus/fast): Distributed systems and caching technologies that minimize latency (HTTP/3, QUIC, congestion control).
+- [More Reliable](https://research.cloudflare.com/focus/reliable): Robust distributed systems and time-synchronization protocols (Roughtime, NTS) that keep the Internet stable at scale.
+- [More Measurable](https://research.cloudflare.com/focus/measurable): Open standards and tooling that make Internet infrastructure verifiable, including Certificate Transparency and large-scale measurement studies.
+
+## About
+
+- [People](https://research.cloudflare.com/people): Profiles of researchers on the team.
+- [Philosophy](https://research.cloudflare.com/philosophy): How the team approaches research and what we publish.
+- [Presentations](https://research.cloudflare.com/presentations): Talks and keynotes given by the team.
+
+## Discovery
+
+- [Sitemap](https://research.cloudflare.com/sitemap-index.xml): Full machine-readable list of every page on the site.
+- [Cloudflare careers in research](https://www.cloudflare.com/careers/jobs/?department=Technology+Research): Open roles on the team.


### PR DESCRIPTION
Two small additions to improve our score on isitagentready.com:

- **`public/_headers`** — Add RFC 8288 `Link:` response headers to the homepage pointing to `/sitemap-index.xml` (already auto-generated by `@astrojs/sitemap`) and the new `/llms.txt`. Lets AI agents discover key resources from HTTP headers without parsing HTML.
- **`public/llms.txt`** — LLM-friendly site index following the [llmstxt.org](https://llmstxt.org/) convention. Summarises the site and links to the five focus areas plus About / Discovery sections, so AI agents can orient themselves without crawling the full HTML site.

### What I deliberately skipped

The scanner flagged several other checks that don't apply to a static content site:
- DNS-AID (DNS records — needs zone admin)
- API catalog (we don't have public APIs)
- OAuth discovery / Protected Resource / `auth.md` (no auth on this site)
- MCP Server Card (no MCP server)
- Agent Skills index (no published skills)
- WebMCP (overkill for read-only content)

Markdown content negotiation would also help (returning `text/markdown` when `Accept: text/markdown` is set), but it's a much bigger lift (generate markdown variants of every page + Workers rewrite rule). Happy to do that in a follow-up if reviewers want it.