### PR TITLE
Add Proxy and Proxies to Spanish glossary do-not-translate list

### DIFF
--- a/i18n/glossaries/es-ES.yaml
+++ b/i18n/glossaries/es-ES.yaml
@@ -122,6 +122,10 @@ doNotTranslate:
   - FOCS
   - STOC
 
+  # others
+  - Proxy
+  - Proxies
+
 # Source-language → preferred translation. The translator should prefer
 # these renderings over its default choice. Curated for research-domain
 # vocabulary (cryptography, networking, distributed systems); marketing

--- a/i18n/overrides/es-ES/tags/proxies.md
+++ b/i18n/overrides/es-ES/tags/proxies.md
@@ -1,0 +1,9 @@
+---
+name: Proxies
+slug: proxies
+description: ""
+color: green
+aiTranslated: true
+aiTranslationModel: "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
+aiTranslatedAt: 2026-07-08T09:59:26.882Z
+---


### PR DESCRIPTION
Adds a small override to the proxies.md tag for Spanish, plus updates the Spanish glossary to avoid translating proxy/proxies.